### PR TITLE
Feature/gil 8 create port group attributes

### DIFF
--- a/drivers/aws_shell_driver/src/driver.py
+++ b/drivers/aws_shell_driver/src/driver.py
@@ -35,6 +35,9 @@ class AWSShellDriver(ResourceDriverInterface):
     def delete(self, context, ports):
         return self.aws_shell.delete_ami(context)
 
+    def destroy_vm_only(self, context, ports):
+        return self.aws_shell.delete_ami(context, False)
+
     def ApplyConnectivityChanges(self, context, ports, request):
         pass
 

--- a/drivers/aws_shell_driver/src/drivermetadata.xml
+++ b/drivers/aws_shell_driver/src/drivermetadata.xml
@@ -13,6 +13,7 @@
         </Category>
         <Category Name="Hidden Commands">
             <Command Description="" DisplayName="Power Cycle" Name="PowerCycle" Tags="power" />
+            <Command Description="" DisplayName="Delete VM Only" Name="destroy_vm_only" Tags="remote_app_management" />
         </Category>
 
         <Category Name="Power">

--- a/package/cloudshell/cp/aws/aws_shell.py
+++ b/package/cloudshell/cp/aws/aws_shell.py
@@ -51,25 +51,13 @@ class AWSShell(object):
         ec2_session = self.aws_session_manager.get_ec2_session(cloudshell_session, aws_ec2_resource_model)
         reservation_id = command_context.reservation.reservation_id
 
-        result = self.deploy_ami_operation.deploy(ec2_session=ec2_session,
-                                                  name=name,
-                                                  reservation_id=reservation_id,
-                                                  aws_ec2_cp_resource_model=aws_ec2_resource_model,
-                                                  ami_deployment_model=aws_ami_deployment_model)
-
-        deploy_data = DeployResult(vm_name=self._get_name_from_tags(result),
-                                   vm_uuid=result.instance_id,
-                                   cloud_provider_resource_name=aws_ami_deployment_model.aws_ec2,
-                                   auto_power_on=aws_ami_deployment_model.auto_power_on,
-                                   auto_power_off=aws_ami_deployment_model.auto_power_off,
-                                   wait_for_ip=aws_ami_deployment_model.wait_for_ip,
-                                   auto_delete=aws_ami_deployment_model.auto_delete,
-                                   autoload=aws_ami_deployment_model.autoload)
+        deploy_data = self.deploy_ami_operation.deploy(ec2_session=ec2_session,
+                                                       name=name,
+                                                       reservation_id=reservation_id,
+                                                       aws_ec2_cp_resource_model=aws_ec2_resource_model,
+                                                       ami_deployment_model=aws_ami_deployment_model)
 
         return self._set_command_result(deploy_data)
-
-    def _get_name_from_tags(self, result):
-        return [tag['Value'] for tag in result.tags if tag['Key'] == 'Name'][0]
 
     def power_on_ami(self, command_context):
         """

--- a/package/cloudshell/cp/aws/device_access_layer/aws_api.py
+++ b/package/cloudshell/cp/aws/device_access_layer/aws_api.py
@@ -51,7 +51,7 @@ class AWSApi(object):
 
         # Reload the instance attributes
         instance.load()
-        return instance, new_name
+        return instance
 
     def set_ec2_resource_tags(self, resource, tags):
         resource.create_tags(Tags=tags)

--- a/package/cloudshell/cp/aws/domain/ami_management/operations/deploy_operation.py
+++ b/package/cloudshell/cp/aws/domain/ami_management/operations/deploy_operation.py
@@ -41,7 +41,7 @@ class DeployAMIOperation(object):
 
         ami_deployment_info = self._create_deployment_parameters(aws_ec2_cp_resource_model,
                                                                  ami_deployment_model,
-                                                                 security_group.group_id)
+                                                                 security_group)
 
         return self.aws_api.create_instance(ec2_session=ec2_session,
                                             name=name,
@@ -50,6 +50,9 @@ class DeployAMIOperation(object):
 
     def _create_security_group_for_instance(self, ami_deployment_model, aws_ec2_cp_resource_model, ec2_session,
                                             reservation_id):
+
+        if not ami_deployment_model.inbound_ports and not ami_deployment_model.outbound_ports:
+            return None
 
         security_group_name = AWSSecurityGroupService.QUALI_SECURITY_GROUP + " " + str(uuid.uuid4())
 
@@ -67,14 +70,14 @@ class DeployAMIOperation(object):
 
         return security_group
 
-    def _create_deployment_parameters(self, aws_ec2_resource_model, ami_deployment_model, security_group_id):
+    def _create_deployment_parameters(self, aws_ec2_resource_model, ami_deployment_model, security_group):
         """
         :param aws_ec2_resource_model: The resource model of the AMI deployment option
         :type aws_ec2_resource_model: cloudshell.cp.aws.models.aws_ec2_cloud_provider_resource_model.AWSEc2CloudProviderResourceModel
         :param ami_deployment_model: The resource model on which the AMI will be deployed on
         :type ami_deployment_model: cloudshell.cp.aws.models.deploy_aws_ec2_ami_instance_resource_model.DeployAWSEc2AMIInstanceResourceModel
-        :param security_group_id : The security group of the AMI
-        :type security_group_id : str
+        :param security_group : The security group of the AMI
+        :type security_group : securityGroup
         """
         aws_model = AMIDeploymentModel()
         if not ami_deployment_model.aws_ami_id:
@@ -89,8 +92,8 @@ class DeployAMIOperation(object):
         aws_model.aws_key = ami_deployment_model.aws_key
         aws_model.subnet_id = aws_ec2_resource_model.subnet
 
-        if security_group_id != '' and security_group_id is not None:
-            aws_model.security_group_ids.append(security_group_id)
+        if security_group is not None:
+            aws_model.security_group_ids.append(security_group.group_id)
         return aws_model
 
     @staticmethod

--- a/package/cloudshell/cp/aws/domain/services/model_parser/port_group_attribute_parser.py
+++ b/package/cloudshell/cp/aws/domain/services/model_parser/port_group_attribute_parser.py
@@ -10,7 +10,7 @@ class PortGroupAttributeParser(object):
 
         if ports_attribute:
             splitted_ports = ports_attribute.split(';')
-            port_data_array = [PortGroupAttributeParser._single_port_parse(port) for port in splitted_ports]
+            port_data_array = [PortGroupAttributeParser._single_port_parse(port.strip()) for port in splitted_ports]
             return port_data_array
         return None
 

--- a/package/cloudshell/cp/aws/models/deploy_result_model.py
+++ b/package/cloudshell/cp/aws/models/deploy_result_model.py
@@ -1,25 +1,26 @@
 class DeployResult(object):
     # def __init__(self, vm_name, vm_uuid, cloud_provider_resource_name, ip_regex, refresh_ip_timeout, auto_power_on,
     #              auto_power_off, wait_for_ip, auto_delete, autoload):
-    def __init__(self, vm_name,vm_uuid, cloud_provider_resource_name,autoload,auto_delete,wait_for_ip,auto_power_off,auto_power_on):
+    def __init__(self, vm_name,vm_uuid, cloud_provider_resource_name,autoload,auto_delete,wait_for_ip,auto_power_off,auto_power_on,inbound_ports,outbound_ports):
         """
         :param str vm_name: The name of the virtual machine
         :param uuid uuid: The UUID
         :param str cloud_provider_resource_name: The Cloud Provider resource name
-        :param str ip_regex: Regex to filter IP address
-        :param int refresh_ip_timeout: Timeout for Refresh IP
         :param boolean auto_power_on:
         :param boolean auto_power_off:
         :param boolean wait_for_ip:
         :param boolean auto_delete:
         :param boolean autoload:
+        :param str inbound_ports:
+        :param str outbound_ports:
         :return:
         """
+
+        self.outbound_ports = outbound_ports
+        self.inbound_ports = inbound_ports
         self.vm_name = vm_name
         self.vm_uuid = vm_uuid
         self.cloud_provider_resource_name = cloud_provider_resource_name
-        # self.ip_regex = ip_regex
-        # self.refresh_ip_timeout = float(refresh_ip_timeout)
         self.auto_power_on = auto_power_on
         self.auto_power_off = auto_power_off
         self.wait_for_ip = wait_for_ip

--- a/package/tests/test_security_groups/test_security_groups.py
+++ b/package/tests/test_security_groups/test_security_groups.py
@@ -19,7 +19,7 @@ class TestSecurityGroups(TestCase):
         self.assertEquals(permission_object['IpProtocol'], self.port_data.protocol)
 
     def test_port_group_parser(self):
-        ports_attribute = "1-3:tcp;1:udp;1-3;1;"
+        ports_attribute = " 1-3:tcp; 1:udp; 1-3;1;  "
         ports = PortGroupAttributeParser.parse_port_group_attribute(ports_attribute)
 
         self.assertEquals(ports[0].from_port, '1')


### PR DESCRIPTION

removing the return of the tuple with the name and the result from the deploy_ami_opreation
when there is no security group it wont create it
adding inbound and outbound ports to deploy result

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/72)
<!-- Reviewable:end -->
