### PR TITLE
Updated data model for the Prepare Connectivity feature

### DIFF
--- a/drivers/aws_shellPackage/DataModel/datamodel.xml
+++ b/drivers/aws_shellPackage/DataModel/datamodel.xml
@@ -166,13 +166,19 @@
         <Rule Name="Setting" />
       </Rules>
     </AttributeInfo>
-    <AttributeInfo DefaultValue="" Description="" IsReadOnly="false" Name="AWS EC2" Type="String">
+    <AttributeInfo DefaultValue="" Description="" IsReadOnly="false" Name="Cloud Provider Resource" Type="String">
       <Rules>
         <Rule Name="Configuration" />
         <Rule Name="Setting" />
       </Rules>
     </AttributeInfo>
     <AttributeInfo DefaultValue="" Description="" IsReadOnly="false" Name="AWS AMI Id" Type="String">
+      <Rules>
+        <Rule Name="Configuration" />
+        <Rule Name="Setting" />
+      </Rules>
+    </AttributeInfo>
+    <AttributeInfo DefaultValue="" Description="" IsReadOnly="false" Name="Networks In Use" Type="String">
       <Rules>
         <Rule Name="Configuration" />
         <Rule Name="Setting" />
@@ -226,6 +232,9 @@
               <AllowedValues />
             </AttachedAttribute>
             <AttachedAttribute IsLocal="true" IsOverridable="true" Name="Default Instance Type">
+              <AllowedValues />
+            </AttachedAttribute>
+            <AttachedAttribute IsLocal="true" IsOverridable="true" Name="Networks In Use">
               <AllowedValues />
             </AttachedAttribute>
           </AttachedAttributes>
@@ -293,7 +302,7 @@
       <Models>
         <ResourceModel Description="" Name="AWS EC2 Instance" SupportsConcurrentCommands="false">
           <AttachedAttributes>
-            <AttachedAttribute IsLocal="true" IsOverridable="true" Name="AWS EC2" UserInput="true">
+            <AttachedAttribute IsLocal="true" IsOverridable="true" Name="Cloud Provider Resource" UserInput="true">
               <AllowedValues />
             </AttachedAttribute>
             <AttachedAttribute IsLocal="true" IsOverridable="true" Name="AWS AMI Id" UserInput="true">

--- a/drivers/deployment_drivers/aws_ec2_ami_instance/driver.py
+++ b/drivers/deployment_drivers/aws_ec2_ami_instance/driver.py
@@ -37,7 +37,7 @@ class DeployAWSEC2AMIInstance(ResourceDriverInterface):
 
         # Calls command on the AWS cloud provider
         result = session.ExecuteCommand(context.reservation.reservation_id,
-                                        aws_ami_deployment_model.aws_ec2,
+                                        aws_ami_deployment_model.cloud_provider_resource,
                                         "Resource",
                                         "deploy_ami",
                                         self._get_command_inputs_list(deployment_info),
@@ -45,14 +45,14 @@ class DeployAWSEC2AMIInstance(ResourceDriverInterface):
         return result.Output
 
     def vaidate_deployment_ami_model(self, aws_ami_deployment_model):
-        if aws_ami_deployment_model.aws_ec2 == '':
-            raise Exception("The name of the AWS EC2 resource is empty.")
+        if aws_ami_deployment_model.cloud_provider_resource == '':
+            raise Exception("The name of the Cloud Provider resource is empty.")
 
     # todo: remove this to a common place
     def _convert_context_to_deployment_resource_model(self, resource):
         deployedResource = DeployAWSEc2AMIInstanceResourceModel()
         deployedResource.aws_ami_id = resource.attributes['AWS AMI Id']
-        deployedResource.aws_ec2 = resource.attributes['AWS EC2']
+        deployedResource.cloud_provider_resource = resource.attributes['Cloud Provider Resource']
         deployedResource.storage_iops = resource.attributes['Storage IOPS']
         deployedResource.storage_size = resource.attributes['Storage Size']
         deployedResource.instance_type = resource.attributes['Instance Type']

--- a/package/cloudshell/cp/aws/domain/ami_management/operations/deploy_operation.py
+++ b/package/cloudshell/cp/aws/domain/ami_management/operations/deploy_operation.py
@@ -58,7 +58,7 @@ class DeployAMIOperation(object):
 
         return DeployResult(vm_name=self._get_name_from_tags(result),
                             vm_uuid=result.instance_id,
-                            cloud_provider_resource_name=ami_deployment_model.aws_ec2,
+                            cloud_provider_resource_name=ami_deployment_model.cloud_provider_resource,
                             auto_power_on=ami_deployment_model.auto_power_on,
                             auto_power_off=ami_deployment_model.auto_power_off,
                             wait_for_ip=ami_deployment_model.wait_for_ip,

--- a/package/cloudshell/cp/aws/domain/services/model_parser/aws_model_parser.py
+++ b/package/cloudshell/cp/aws/domain/services/model_parser/aws_model_parser.py
@@ -35,7 +35,7 @@ class AWSModelsParser(object):
         data = jsonpickle.decode(deployment_request)
         data_holder = DeployDataHolder(data)
         deployment_resource_model = DeployAWSEc2AMIInstanceResourceModel()
-        deployment_resource_model.aws_ec2 = data_holder.ami_params.aws_ec2
+        deployment_resource_model.cloud_provider_resource = data_holder.ami_params.cloud_provider_resource
         deployment_resource_model.aws_ami_id = data_holder.ami_params.aws_ami_id
         deployment_resource_model.storage_size = data_holder.ami_params.storage_size
         deployment_resource_model.storage_iops = data_holder.ami_params.storage_iops

--- a/package/cloudshell/cp/aws/models/deploy_aws_ec2_ami_instance_resource_model.py
+++ b/package/cloudshell/cp/aws/models/deploy_aws_ec2_ami_instance_resource_model.py
@@ -1,6 +1,6 @@
 class DeployAWSEc2AMIInstanceResourceModel(object):
     def __init__(self):
-        self.aws_ec2 = ''
+        self.cloud_provider_resource = ''
         self.aws_ami_id = ''
         self.storage_size = ''
         self.storage_iops = ''

--- a/package/tests/test_ami_management/test_operations/test_deploy_operation.py
+++ b/package/tests/test_ami_management/test_operations/test_deploy_operation.py
@@ -37,7 +37,7 @@ class TestDeployOperation(TestCase):
         ami_credentials = self.credentials_manager.get_windows_credentials()
 
         self.assertEqual(res.vm_name, 'my name')
-        self.assertEqual(res.cloud_provider_resource_name, ami_datamodel.aws_ec2)
+        self.assertEqual(res.cloud_provider_resource_name, ami_datamodel.cloud_provider_resource)
         self.assertEqual(res.auto_power_on, ami_datamodel.auto_power_on)
         self.assertEqual(res.auto_power_off, ami_datamodel.auto_power_off)
         self.assertEqual(res.wait_for_ip, ami_datamodel.wait_for_ip)

--- a/package/tests/test_aws_shell.py
+++ b/package/tests/test_aws_shell.py
@@ -45,11 +45,11 @@ class TestAWSShell(TestCase):
         deploymock.wait_for_ip = "True"
         deploymock.auto_delete = "True"
         deploymock.autoload = "True"
-        deploymock.aws_ec2 = "some_name"
+        deploymock.cloud_provider_resource = "some_name"
 
         result = DeployResult(vm_name=name,
                               vm_uuid='my instance id',
-                              cloud_provider_resource_name=deploymock.aws_ec2,
+                              cloud_provider_resource_name=deploymock.cloud_provider_resource,
                               autoload=deploymock.autoload,
                               auto_delete=deploymock.auto_delete,
                               wait_for_ip=deploymock.wait_for_ip,
@@ -76,7 +76,7 @@ class TestAWSShell(TestCase):
         self.assertEqual(decoded_res['wait_for_ip'], deploymock.wait_for_ip)
         self.assertEqual(decoded_res['auto_delete'], deploymock.auto_delete)
         self.assertEqual(decoded_res['autoload'], deploymock.autoload)
-        self.assertEqual(decoded_res['cloud_provider_resource_name'], deploymock.aws_ec2)
+        self.assertEqual(decoded_res['cloud_provider_resource_name'], deploymock.cloud_provider_resource)
 
     def test_power_on(self):
         deployed_model = DeployDataHolder({'vmdetails': {'uid': 'id'}})


### PR DESCRIPTION
- Changed "AWS EC2" attribute to "Cloud Provider Resource" attribute
- Added "Networks In Use" attribute on the Cloud Provider resource - this attribute is used by Prepare Connectivity for the exclusion of used networks in CIDR format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/98)
<!-- Reviewable:end -->
