### PR TITLE
Mocked PrepareConnectivity so that setup script will not fail

### DIFF
--- a/drivers/aws_shell/src/driver.py
+++ b/drivers/aws_shell/src/driver.py
@@ -42,7 +42,10 @@ class AWSShellDriver(ResourceDriverInterface):
         pass
 
     def PrepareConnectivity(self, context, request):
-        return "MOCK-PrepareConnectivity"
+        return "{ driverResponse: { actionResults: [{success: true}] } }"
+
+    def CleanupConnectivity(self, context, request):
+        return "{ driverResponse: { actionResults: [{success: true}] } }"
 
     def GetApplicationPorts(self, context, ports):
         return self.aws_shell.get_application_ports(context)

--- a/drivers/aws_shell/src/drivermetadata.xml
+++ b/drivers/aws_shell/src/drivermetadata.xml
@@ -7,7 +7,8 @@
             <Command Description="" DisplayName="Refresh IP" EnableCancellation="true" Name="remote_refresh_ip" Tags="remote_connectivity,allow_shared" />
             <Command Description="" DisplayName="Get Application Ports" EnableCancellation="true" Name="GetApplicationPorts" Tags="remote_connectivity,allow_shared" />
             <Command Description="" DisplayName="Apply Connectivity Changes" Name="ApplyConnectivityChanges" Tags="allow_unreserved" />
-            <Command Description="" DisplayName="Prepare Connectivity Changes" Name="PrepareConnectivity" Tags="allow_unreserved" />
+            <Command Description="" DisplayName="Prepare Connectivity" Name="PrepareConnectivity" Tags="allow_unreserved" />
+            <Command Description="" DisplayName="Cleanup Connectivity" Name="CleanupConnectivity" Tags="allow_unreserved" />
         </Category>
         <Category Name="App Management">
             <Command Description="" DisplayName="Delete" Name="delete" Tags="remote_app_management,allow_shared" />


### PR DESCRIPTION
1. Mocked PrepareConnectivity so that setup script will not fail
2. Fixed display names in aws shell driver for connectivity commands

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/99)
<!-- Reviewable:end -->
