### PR TITLE
Igor 163306 get app ports

### DIFF
--- a/package/cloudshell/cp/aws/domain/services/parsers/aws_model_parser.py
+++ b/package/cloudshell/cp/aws/domain/services/parsers/aws_model_parser.py
@@ -150,8 +150,10 @@ class AWSModelsParser(object):
         allow_traffic_on_resource = ""
         allow_all_storage_traffic = 'Allow all Sandbox Traffic'
         if resource_context.remote_endpoints is not None:
+            data = jsonpickle.decode(resource_context.remote_endpoints[0].app_context.app_request_json)
+            attributes = {d["name"]: d["value"] for d in data["deploymentService"]["attributes"]}
             allow_traffic_on_resource = AWSModelsParser.get_attribute_value_by_name_ignoring_namespace(
-                resource_context.remote_endpoints[0].attributes, allow_all_storage_traffic)
+                attributes, allow_all_storage_traffic)
         return allow_traffic_on_resource
 
     @staticmethod

--- a/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
+++ b/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
@@ -77,6 +77,11 @@ class TestDeployedAppPortsOperation(TestCase):
     def test_get_app_ports_from_cloud_provider(self):
         instance = Mock()
         instance.network_interfaces = []
+        instance.subnet = Mock()
+
+        name_dict = {"Key": "Name", "Value": "Just a name"}
+        reservation_id_dict = {"Key": "ReservationId", "Value": "Reservation Id"}
+        instance.subnet.tags = [name_dict, reservation_id_dict]
         self.instance_service.get_active_instance_by_id = Mock(return_value=instance)
 
         remote_resource = Mock()
@@ -89,6 +94,3 @@ class TestDeployedAppPortsOperation(TestCase):
                                                                   allow_all_storage_traffic=True)
 
         self.assertEquals(result, 'App Name: my ami name\nAllow Sandbox Traffic: True')
-
-
-

--- a/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
+++ b/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
@@ -82,6 +82,7 @@ class TestDeployedAppPortsOperation(TestCase):
         name_dict = {"Key": "Name", "Value": "Just a name"}
         reservation_id_dict = {"Key": "ReservationId", "Value": "Reservation Id"}
         instance.subnet.tags = [name_dict, reservation_id_dict]
+        
         self.instance_service.get_active_instance_by_id = Mock(return_value=instance)
 
         remote_resource = Mock()


### PR DESCRIPTION
- When calling Get Application Ports command source should be retrieved even if no inbound ports were defined 
- Subnet name should be displayed when calling "Get Application Ports" command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/394)
<!-- Reviewable:end -->
