### PR TITLE
Bug: Running getApplicationPort command on AWS app connected to two s…

### DIFF
--- a/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
+++ b/package/tests/test_deployed_app/test_operations/test_app_ports_operation.py
@@ -82,7 +82,7 @@ class TestDeployedAppPortsOperation(TestCase):
         name_dict = {"Key": "Name", "Value": "Just a name"}
         reservation_id_dict = {"Key": "ReservationId", "Value": "Reservation Id"}
         instance.subnet.tags = [name_dict, reservation_id_dict]
-        
+
         self.instance_service.get_active_instance_by_id = Mock(return_value=instance)
 
         remote_resource = Mock()


### PR DESCRIPTION
Running getApplicationPort command on AWS app connected to two subnets will return only the name of one of the subnets twice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/395)
<!-- Reviewable:end -->
