### PR TITLE
Get application ports command - When source is not defined do not dis…

### DIFF
--- a/package/cloudshell/cp/aws/domain/deployed_app/operations/app_ports_operation.py
+++ b/package/cloudshell/cp/aws/domain/deployed_app/operations/app_ports_operation.py
@@ -91,15 +91,11 @@ class DeployedAppPortsOperation(object):
                 if inbound_ports_security_group:
                     security_groups.append(inbound_ports_security_group)
 
-                if not security_groups:
-                    source = instance.subnet.cidr_block
-                    result_str_list.append('Source: ' + source)
-                else:
-                    # convert ip permissions of security groups to string
-                    for security_group in security_groups:
-                        ip_permissions_string = self._ip_permissions_to_string(security_group.ip_permissions)
-                        if ip_permissions_string:
-                            result_str_list.append(ip_permissions_string)
+                # convert ip permissions of security groups to string
+                for security_group in security_groups:
+                    ip_permissions_string = self._ip_permissions_to_string(security_group.ip_permissions)
+                    if ip_permissions_string:
+                        result_str_list.append(ip_permissions_string)
 
         return '\n'.join(result_str_list).strip()
 


### PR DESCRIPTION
Get application ports command - When source is not defined do not display field "source"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/405)
<!-- Reviewable:end -->
