### PR TITLE
#164644

### DIFF
--- a/drivers/aws_shell/src/requirements.txt
+++ b/drivers/aws_shell/src/requirements.txt
@@ -1,4 +1,4 @@
 cloudshell-automation-api>=8.2.0.0,<8.2.1.0
 cloudshell-shell-core>=3.1.0,<3.2.0
-cloudshell-cp-aws>=2.0.0,<2.1.0
+cloudshell-cp-aws>=2.1.0,<2.2.0
 jsonpickle==0.9.3

--- a/package/cloudshell/cp/aws/domain/common/list_helper.py
+++ b/package/cloudshell/cp/aws/domain/common/list_helper.py
@@ -5,3 +5,14 @@ def first_or_default(lst, lambda_expression):
 
 def single(lst, lambda_expression):
     return filter(lambda_expression, lst)[0]
+
+
+def index_of(lst, lambda_predicate):
+    gen = (index for index, item in enumerate(lst) if lambda_predicate(item))
+
+    try:
+        first = gen.next()
+    except StopIteration:
+        return None
+
+    return first

--- a/package/cloudshell/cp/aws/domain/conncetivity/operations/cleanup.py
+++ b/package/cloudshell/cp/aws/domain/conncetivity/operations/cleanup.py
@@ -49,7 +49,7 @@ class CleanupConnectivityOperation(object):
 
             logger.info("Deleting vpc and removing dependencies")
             self.vpc_service.remove_all_internet_gateways(vpc)
-            self.vpc_service.remove_all_security_groups(vpc)
+            self.vpc_service.remove_all_security_groups(vpc, reservation_id)
             self.vpc_service.remove_all_subnets(vpc)
             self.vpc_service.remove_all_peering(vpc)
             self._delete_blackhole_routes_in_vpc_route_table(ec2_session, ec2_client, aws_ec2_data_model)

--- a/package/cloudshell/cp/aws/domain/services/ec2/security_group.py
+++ b/package/cloudshell/cp/aws/domain/services/ec2/security_group.py
@@ -24,11 +24,6 @@ class SecurityGroupService(object):
             sg.delete()
         return True
 
-    def delete_all_security_groups_of_instance(self, instance):
-        if instance.security_groups:
-            for security_group in instance.security_groups:
-                self.delete_security_group(security_group)
-
     def create_security_group(self, ec2_session, vpc_id, security_group_name):
         """
         creating a security group

--- a/package/cloudshell/cp/aws/domain/services/ec2/vpc.py
+++ b/package/cloudshell/cp/aws/domain/services/ec2/vpc.py
@@ -2,6 +2,7 @@ import traceback
 from retrying import retry
 from cloudshell.cp.aws.common import retry_helper
 from cloudshell.cp.aws.models.aws_ec2_cloud_provider_resource_model import AWSEc2CloudProviderResourceModel
+from cloudshell.cp.aws.domain.common.list_helper import index_of
 
 
 class VPCService(object):
@@ -226,15 +227,29 @@ class VPCService(object):
                 peer.delete()
         return True
 
-    def remove_all_security_groups(self, vpc):
+    def remove_all_security_groups(self, vpc, reservation_id):
         """
         Will remove all security groups to the VPC
         :param vpc: EC2 VPC instance
+        :param str reservation_id: The reservation id
         :return:
         """
         security_groups = list(vpc.security_groups.all())
+
+        # its possible that a group is dependent on an isolated group so we must delete the isolated group LAST
+        isolated_sg_name =  self.sg_service.sandbox_isolated_sg_name(reservation_id)
+
+        # trying to find isolated group index
+        isolated_ix =  index_of(security_groups, lambda sg: sg.group_name == isolated_sg_name)
+
+        # if there is one
+        if(isolated_ix):
+            # move isolated group to the end
+            security_groups.insert(len(security_groups), security_groups.pop(isolated_ix))
+
         for sg in security_groups:
             self.sg_service.delete_security_group(sg)
+
         return True
 
     def remove_all_subnets(self, vpc):

--- a/package/tests/test_domain_services/test_security_groups.py
+++ b/package/tests/test_domain_services/test_security_groups.py
@@ -51,11 +51,11 @@ class TestSecurityGroups(TestCase):
         sg.delete = Mock(side_effect=Exception())
         self.assertRaises(Exception, self.sg_service.delete_security_group, sg)
 
-    def test_instance_sg(self):
-        instance = Mock()
-        instance.security_groups = [Mock(), Mock()]
-        self.sg_service.delete_all_security_groups_of_instance(instance)
-        self.assertTrue(instance.security_groups[0].delete.callled and instance.security_groups[1].delete.callled)
+    # def test_instance_sg(self):
+    #     instance = Mock()
+    #     instance.security_groups = [Mock(), Mock()]
+    #     self.sg_service.delete_all_security_groups_of_instance(instance)
+    #     self.assertTrue(instance.security_groups[0].delete.callled and instance.security_groups[1].delete.callled)
 
     def test_create_sg(self):
         ec2_session = Mock()

--- a/package/tests/test_domain_services/test_vpc.py
+++ b/package/tests/test_domain_services/test_vpc.py
@@ -137,7 +137,8 @@ class TestVPCService(TestCase):
         self.vpc.security_groups = Mock()
         self.vpc.security_groups.all = Mock(return_value=[sg])
 
-        res = self.vpc_service.remove_all_security_groups(self.vpc)
+        res = self.vpc_service.remove_all_security_groups(self.vpc, self.reservation.reservation_id )
+        res = self.vpc_service.remove_all_security_groups(self.vpc, self.reservation.reservation_id )
 
         self.assertTrue(res)
         self.assertTrue(self.sg_service.delete_security_group.called_with(sg))

--- a/package/tests/test_domain_services/test_vpc.py
+++ b/package/tests/test_domain_services/test_vpc.py
@@ -138,7 +138,6 @@ class TestVPCService(TestCase):
         self.vpc.security_groups.all = Mock(return_value=[sg])
 
         res = self.vpc_service.remove_all_security_groups(self.vpc, self.reservation.reservation_id )
-        res = self.vpc_service.remove_all_security_groups(self.vpc, self.reservation.reservation_id )
 
         self.assertTrue(res)
         self.assertTrue(self.sg_service.delete_security_group.called_with(sg))


### PR DESCRIPTION
bug occurred when a trying to delete security group(isolated) when it is referenced in another's group rule.
so now we make sure we delete isolated group last.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/415)
<!-- Reviewable:end -->
