### PR TITLE
case insensitive protocol in inbound ports

### DIFF
--- a/package/cloudshell/cp/aws/domain/services/parsers/port_group_attribute_parser.py
+++ b/package/cloudshell/cp/aws/domain/services/parsers/port_group_attribute_parser.py
@@ -45,13 +45,13 @@ class PortGroupAttributeParser(object):
         tcp = 'tcp'
 
         from_to_protocol_match = re.match(r"^((?P<from_port>\d+)-(?P<to_port>\d+):(?P<protocol>(udp|tcp)))$",
-                                          ports_attribute)
+                                          ports_attribute, flags=re.IGNORECASE)
 
         # 80-50000:udp
         if from_to_protocol_match:
             from_port = from_to_protocol_match.group(from_port)
             to_port = from_to_protocol_match.group(to_port)
-            protocol = from_to_protocol_match.group(protocol)
+            protocol = from_to_protocol_match.group(protocol).lower()
             return PortData(from_port, to_port, protocol, destination)
 
         from_protocol_match = re.match(r"^((?P<from_port>\d+):(?P<protocol>(udp|tcp)))$", ports_attribute)


### PR DESCRIPTION
Bug 169055:AWS: UDP and TCP ports definitions are case sensitive

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qualisystems/aws-shell/474)
<!-- Reviewable:end -->
